### PR TITLE
Add codespaces experiment split

### DIFF
--- a/quest.yml
+++ b/quest.yml
@@ -17,6 +17,7 @@ solutionBranch: quest_solution/docker_localsetup
 steps:
 - setup_docker_generic
 - setup_docker_continue_generic
+- setup_docker_continue_codespace_generic
 - setup_backend_docker_generic
 - setup_frontend_docker_generic
 - setup_readme_docker_generic

--- a/steps/setup_backend_docker_generic.yml
+++ b/steps/setup_backend_docker_generic.yml
@@ -3,16 +3,33 @@ hints:
 - Pssst - you can run `docker-compose up` from the root directory
 - run `docker exec -it <container-name> sh` to access a container from the terminal.
 startFlow:
-  do:
-  - actionId: bot_message
-    params:
-      person: head-of-rd
-      messages:
-      - text: If Docker is working correctly, the backend should be running and able
-          to connect to your local database.
-        delay: 2000
-      - text: Let's test this by **pointing your browser** to http://localhost:3000/api/ping
-        delay: 1000
+  if:
+    conditions:
+    - conditionId: user_has_feature_flag
+      params:
+        featureFlag: 'codespaces'
+    then:
+      do:
+      - actionId: bot_message
+        params:
+          person: head-of-rd
+          messages:
+          - text: If Docker is working correctly, the backend should be running and able
+              to connect to your local database.
+            delay: 2000
+          - text: Let's test this by **pointing your browser** to https://${user.codespace.name}-3000.githubpreview.dev/api/ping
+            delay: 1000
+    else:
+      do:
+      - actionId: bot_message
+        params:
+          person: head-of-rd
+          messages:
+          - text: If Docker is working correctly, the backend should be running and able
+              to connect to your local database.
+            delay: 2000
+          - text: Let's test this by **pointing your browser** to http://localhost:3000/api/ping
+            delay: 1000
 trigger:
   type: ping
   flowNode:

--- a/steps/setup_backend_docker_generic.yml
+++ b/steps/setup_backend_docker_generic.yml
@@ -14,8 +14,8 @@ startFlow:
         params:
           person: head-of-rd
           messages:
-          - text: If docker-compose is working correctly and finished loading up, the backend should be running and able
-              to connect to your local database.
+          - text: Once docker-compose finishes loading up, the backend should be running and able
+              to connect to the database.
             delay: 2000
           - text: Let's test this by **pointing your browser** to https://${user.codespace.name}-3000.githubpreview.dev/api/ping
             delay: 1000

--- a/steps/setup_backend_docker_generic.yml
+++ b/steps/setup_backend_docker_generic.yml
@@ -14,7 +14,7 @@ startFlow:
         params:
           person: head-of-rd
           messages:
-          - text: If Docker is working correctly, the backend should be running and able
+          - text: If docker-compose is working correctly and finished loading up, the backend should be running and able
               to connect to your local database.
             delay: 2000
           - text: Let's test this by **pointing your browser** to https://${user.codespace.name}-3000.githubpreview.dev/api/ping

--- a/steps/setup_docker_continue_codespace_generic.yml
+++ b/steps/setup_docker_continue_codespace_generic.yml
@@ -17,7 +17,6 @@ trigger:
             person: head-of-rd
             messages:
             - text: |-
-                Great! Looks like your codespace is up and running. You can now
-                **run \`docker-compose up\` in your codespace's terminal** to load Anythink's backend and frontend.
+                Great! Looks like your codespace is up and running. You can now **run \`docker-compose up\` in your codespace's terminal** to load Anythink's backend and frontend.
               delay: 3000
         - actionId: finish_step

--- a/steps/setup_docker_continue_codespace_generic.yml
+++ b/steps/setup_docker_continue_codespace_generic.yml
@@ -1,0 +1,23 @@
+id: setup_docker_continue_codespace_generic
+hints:
+- Make sure your codespace has started and is ready to use.
+startFlow:
+trigger:
+  type: github_codespace_started
+  flowNode:
+    if:
+      conditions:
+      - conditionId: user_has_feature_flag
+        params:
+          featureFlag: 'codespaces'
+      then:
+        do:
+        - actionId: bot_message
+          params:
+            person: head-of-rd
+            messages:
+            - text: |-
+                Great! Looks like your codespace is up and running. You can now
+                **run \`docker-compose up\` in your codespace's terminal** to load Anythink's backend and frontend.
+              delay: 3000
+        - actionId: finish_step

--- a/steps/setup_docker_continue_codespace_generic.yml
+++ b/steps/setup_docker_continue_codespace_generic.yml
@@ -2,6 +2,15 @@ id: setup_docker_continue_codespace_generic
 hints:
 - Make sure your codespace has started and is ready to use.
 startFlow:
+  if:
+    conditions:
+    - conditionId: user_has_feature_flag
+      equals: false
+      params:
+        featureFlag: 'codespaces'
+    then:
+      do:
+      - actionId: finish_step
 trigger:
   type: github_codespace_started
   flowNode:

--- a/steps/setup_docker_continue_generic.yml
+++ b/steps/setup_docker_continue_generic.yml
@@ -8,9 +8,7 @@ hints:
 - Make sure you ran the \`docker-compose up\` command from the **project root directory**
   and that it finished running. This may take a few moments.
 startFlow:
-trigger:
-  type: github_codespace_started
-  flowNode:
+  do:
     if:
       conditions:
       - conditionId: user_has_feature_flag
@@ -18,14 +16,6 @@ trigger:
           featureFlag: 'codespaces'
       then:
         do:
-        - actionId: bot_message
-          params:
-            person: head-of-rd
-            messages:
-            - text: |-
-                Great! Looks like your codespace is up and running. You can now
-                **run \`docker-compose up\` in your codespace's terminal** to load Anythink's backend and frontend.
-              delay: 3000
         - actionId: finish_step
 trigger:
   type: user_message

--- a/steps/setup_docker_continue_generic.yml
+++ b/steps/setup_docker_continue_generic.yml
@@ -23,35 +23,28 @@ trigger:
   flowNode:
     if:
       conditions:
-      - conditionId: user_has_feature_flag
-        equals: false
-        params:
-          featureFlag: 'codespaces'
+      - conditionId: is_user_message_text_ready_to_continue
       then:
-        if:
-          conditions:
-          - conditionId: is_user_message_text_ready_to_continue
-          then:
-            do:
-            - actionId: bot_message
-              params:
-                person: head-of-rd
-                messages:
-                - text: |-
-                    Great! You can verify docker is ready by running the following commands in your terminal: \`docker -v\` and \`docker-compose -v\`.
-                    Then, **run \`docker-compose up\` from the project root directory** to load Anythink's backend and frontend.
-                  delay: 3000
-                - text: Ok. That’s a great first step - now we can make sure that the
-                    code is working :)
-                  delay: 2000
-            - actionId: finish_step
-          else:
-            do:
-            - actionId: bot_message
-              params:
-                person: head-of-rd
-                messages:
-                - text: Umm, If you need any help, just let me know that you’re stuck.
-                    If that’s not the case - take your time and tell me once you're ready
-                    :)
-                  delay: 2000
+        do:
+        - actionId: bot_message
+          params:
+            person: head-of-rd
+            messages:
+            - text: |-
+                Great! You can verify docker is ready by running the following commands in your terminal: \`docker -v\` and \`docker-compose -v\`.
+                Then, **run \`docker-compose up\` from the project root directory** to load Anythink's backend and frontend.
+              delay: 3000
+            - text: Ok. That’s a great first step - now we can make sure that the
+                code is working :)
+              delay: 2000
+        - actionId: finish_step
+      else:
+        do:
+        - actionId: bot_message
+          params:
+            person: head-of-rd
+            messages:
+            - text: Umm, If you need any help, just let me know that you’re stuck.
+                If that’s not the case - take your time and tell me once you're ready
+                :)
+              delay: 2000

--- a/steps/setup_docker_continue_generic.yml
+++ b/steps/setup_docker_continue_generic.yml
@@ -8,15 +8,14 @@ hints:
 - Make sure you ran the \`docker-compose up\` command from the **project root directory**
   and that it finished running. This may take a few moments.
 startFlow:
-  do:
-    if:
-      conditions:
-      - conditionId: user_has_feature_flag
-        params:
-          featureFlag: 'codespaces'
-      then:
-        do:
-        - actionId: finish_step
+  if:
+    conditions:
+    - conditionId: user_has_feature_flag
+      params:
+        featureFlag: 'codespaces'
+    then:
+      do:
+      - actionId: finish_step
 trigger:
   type: user_message
   params:
@@ -29,31 +28,30 @@ trigger:
         params:
           featureFlag: 'codespaces'
       then:
-        do:
-          if:
-            conditions:
-            - conditionId: is_user_message_text_ready_to_continue
-            then:
-              do:
-              - actionId: bot_message
-                params:
-                  person: head-of-rd
-                  messages:
-                  - text: |-
-                      Great! You can verify docker is ready by running the following commands in your terminal: \`docker -v\` and \`docker-compose -v\`.
-                      Then, **run \`docker-compose up\` from the project root directory** to load Anythink's backend and frontend.
-                    delay: 3000
-                  - text: Ok. That’s a great first step - now we can make sure that the
-                      code is working :)
-                    delay: 2000
-              - actionId: finish_step
-            else:
-              do:
-              - actionId: bot_message
-                params:
-                  person: head-of-rd
-                  messages:
-                  - text: Umm, If you need any help, just let me know that you’re stuck.
-                      If that’s not the case - take your time and tell me once you're ready
-                      :)
-                    delay: 2000
+        if:
+          conditions:
+          - conditionId: is_user_message_text_ready_to_continue
+          then:
+            do:
+            - actionId: bot_message
+              params:
+                person: head-of-rd
+                messages:
+                - text: |-
+                    Great! You can verify docker is ready by running the following commands in your terminal: \`docker -v\` and \`docker-compose -v\`.
+                    Then, **run \`docker-compose up\` from the project root directory** to load Anythink's backend and frontend.
+                  delay: 3000
+                - text: Ok. That’s a great first step - now we can make sure that the
+                    code is working :)
+                  delay: 2000
+            - actionId: finish_step
+          else:
+            do:
+            - actionId: bot_message
+              params:
+                person: head-of-rd
+                messages:
+                - text: Umm, If you need any help, just let me know that you’re stuck.
+                    If that’s not the case - take your time and tell me once you're ready
+                    :)
+                  delay: 2000

--- a/steps/setup_docker_continue_generic.yml
+++ b/steps/setup_docker_continue_generic.yml
@@ -9,7 +9,7 @@ hints:
   and that it finished running. This may take a few moments.
 startFlow:
 trigger:
-  type: github_codespace_added_to_user
+  type: github_codespace_started
   flowNode:
     if:
       conditions:

--- a/steps/setup_docker_continue_generic.yml
+++ b/steps/setup_docker_continue_generic.yml
@@ -9,13 +9,13 @@ hints:
   and that it finished running. This may take a few moments.
 startFlow:
 trigger:
-  type: user_message
-  params:
-    person: head-of-rd
+  type: github_codespace_added_to_user
   flowNode:
     if:
       conditions:
-      - conditionId: is_user_message_text_ready_to_continue
+      - conditionId: user_has_feature_flag
+        params:
+          featureFlag: 'codespaces'
       then:
         do:
         - actionId: bot_message
@@ -23,20 +23,47 @@ trigger:
             person: head-of-rd
             messages:
             - text: |-
-                Great! You can verify docker is ready by running the following commands in your terminal: \`docker -v\` and \`docker-compose -v\`.
-                Then, **run \`docker-compose up\` from the project root directory** to load Anythink's backend and frontend.
+                Great! Looks like your codespace is up and running. You can now
+                **run \`docker-compose up\` in your codespace's terminal** to load Anythink's backend and frontend.
               delay: 3000
-            - text: Ok. That’s a great first step - now we can make sure that the
-                code is working :)
-              delay: 2000
         - actionId: finish_step
-      else:
+trigger:
+  type: user_message
+  params:
+    person: head-of-rd
+  flowNode:
+    if:
+      conditions:
+      - conditionId: user_has_feature_flag
+        equals: false
+        params:
+          featureFlag: 'codespaces'
+      then:
         do:
-        - actionId: bot_message
-          params:
-            person: head-of-rd
-            messages:
-            - text: Umm, If you need any help, just let me know that you’re stuck.
-                If that’s not the case - take your time and tell me once you're ready
-                :)
-              delay: 2000
+          if:
+            conditions:
+            - conditionId: is_user_message_text_ready_to_continue
+            then:
+              do:
+              - actionId: bot_message
+                params:
+                  person: head-of-rd
+                  messages:
+                  - text: |-
+                      Great! You can verify docker is ready by running the following commands in your terminal: \`docker -v\` and \`docker-compose -v\`.
+                      Then, **run \`docker-compose up\` from the project root directory** to load Anythink's backend and frontend.
+                    delay: 3000
+                  - text: Ok. That’s a great first step - now we can make sure that the
+                      code is working :)
+                    delay: 2000
+              - actionId: finish_step
+            else:
+              do:
+              - actionId: bot_message
+                params:
+                  person: head-of-rd
+                  messages:
+                  - text: Umm, If you need any help, just let me know that you’re stuck.
+                      If that’s not the case - take your time and tell me once you're ready
+                      :)
+                    delay: 2000

--- a/steps/setup_docker_generic.yml
+++ b/steps/setup_docker_generic.yml
@@ -58,33 +58,33 @@ trigger:
               then:
                 do:
                 - actionId: bot_message
-                params:
-                  person: head-of-rd
-                  messages:
-                  - text: At Anythink, our engineers work with a development environment that's hosted in the cloud called [Github Codespace](https://docs.github.com/en/codespaces/overview). No need to install anything on your own computer!
-                    delay: 2000
-                  - text: Here's the link to [create your own codespace environment](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=${user.repoId}).
-                    delay: 1000
-                  - text: It takes about a minute to boot. Once it's up and ready you can start working directly in the browser or use VS Code to connect to the codespace in the cloud.
-                    delay: 2000
-                  - text: Go ahead and boot up your codespace, I'll wait.
-                    delay: 1000 # check how setup quest works when waiting for github invitation approval
+                  params:
+                    person: head-of-rd
+                    messages:
+                    - text: At Anythink, our engineers work with a development environment that's hosted in the cloud called [Github Codespace](https://docs.github.com/en/codespaces/overview). No need to install anything on your own computer!
+                      delay: 2000
+                    - text: Here's the link to [create your own codespace environment](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=${user.repoId}).
+                      delay: 1000
+                    - text: It takes about a minute to boot. Once it's up and ready you can start working directly in the browser or use VS Code to connect to the codespace in the cloud.
+                      delay: 2000
+                    - text: Go ahead and boot up your codespace, I'll wait.
+                      delay: 1000
                 - actionId: finish_step
 
               else:
                 do:
                 - actionId: bot_message
-                params:
-                  person: head-of-rd
-                  messages:
-                  - text: Before we dive into the code, we need Docker. It’s going to make
-                      it easier for us to run things locally, which we’ll have to do a lot
-                      during your work here.
-                    delay: 2000
-                  - text: "**So first thing’s first - [install Docker](https://docs.docker.com/get-docker/).**"
-                    delay: 5500
-                  - text: Write me back when you're done. K?
-                    delay: 3000
+                  params:
+                    person: head-of-rd
+                    messages:
+                    - text: Before we dive into the code, we need Docker. It’s going to make
+                        it easier for us to run things locally, which we’ll have to do a lot
+                        during your work here.
+                      delay: 2000
+                    - text: "**So first thing’s first - [install Docker](https://docs.docker.com/get-docker/).**"
+                      delay: 5500
+                    - text: Write me back when you're done. K?
+                      delay: 3000
                 - actionId: finish_step
       else:
         do:

--- a/steps/setup_docker_generic.yml
+++ b/steps/setup_docker_generic.yml
@@ -50,15 +50,42 @@ trigger:
               delay: 4000
             - text: _Anyway, the DIB!_
               delay: 4000
-            - text: Before we dive into the code, we need Docker. It’s going to make
-                it easier for us to run things locally, which we’ll have to do a lot
-                during your work here.
-              delay: 2000
-            - text: "**So first thing’s first - [install Docker](https://docs.docker.com/get-docker/).**"
-              delay: 5500
-            - text: Write me back when you're done. K?
-              delay: 3000
-        - actionId: finish_step
+            if:
+              conditions:
+              - conditionId: user_has_feature_flag
+                params:
+                  featureFlag: 'codespaces'
+              then:
+                do:
+                - actionId: bot_message
+                params:
+                  person: head-of-rd
+                  messages:
+                  - text: At Anythink, our engineers work with a development environment that's hosted in the cloud called [Github Codespace](https://docs.github.com/en/codespaces/overview). No need to install anything on your own computer!
+                    delay: 2000
+                  - text: Here's the link to [create your own codespace environment](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=${user.repoId}).
+                    delay: 1000
+                  - text: It takes about a minute to boot. Once it's up and ready you can start working directly in the browser or use VS Code to connect to the codespace in the cloud.
+                    delay: 2000
+                  - text: Go ahead and boot up your codespace, I'll wait.
+                    delay: 1000 # check how setup quest works when waiting for github invitation approval
+                - actionId: finish_step
+
+              else:
+                do:
+                - actionId: bot_message
+                params:
+                  person: head-of-rd
+                  messages:
+                  - text: Before we dive into the code, we need Docker. It’s going to make
+                      it easier for us to run things locally, which we’ll have to do a lot
+                      during your work here.
+                    delay: 2000
+                  - text: "**So first thing’s first - [install Docker](https://docs.docker.com/get-docker/).**"
+                    delay: 5500
+                  - text: Write me back when you're done. K?
+                    delay: 3000
+                - actionId: finish_step
       else:
         do:
         - actionId: bot_message

--- a/steps/setup_docker_generic.yml
+++ b/steps/setup_docker_generic.yml
@@ -50,42 +50,41 @@ trigger:
               delay: 4000
             - text: _Anyway, the DIB!_
               delay: 4000
-            if:
-              conditions:
-              - conditionId: user_has_feature_flag
-                params:
-                  featureFlag: 'codespaces'
-              then:
-                do:
-                - actionId: bot_message
-                  params:
-                    person: head-of-rd
-                    messages:
-                    - text: At Anythink, our engineers work with a development environment that's hosted in the cloud called [Github Codespace](https://docs.github.com/en/codespaces/overview). No need to install anything on your own computer!
-                      delay: 2000
-                    - text: Here's the link to [create your own codespace environment](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=${user.repoId}).
-                      delay: 1000
-                    - text: It takes about a minute to boot. Once it's up and ready you can start working directly in the browser or use VS Code to connect to the codespace in the cloud.
-                      delay: 2000
-                    - text: Go ahead and boot up your codespace, I'll wait.
-                      delay: 1000
-                - actionId: finish_step
-
-              else:
-                do:
-                - actionId: bot_message
-                  params:
-                    person: head-of-rd
-                    messages:
-                    - text: Before we dive into the code, we need Docker. It’s going to make
-                        it easier for us to run things locally, which we’ll have to do a lot
-                        during your work here.
-                      delay: 2000
-                    - text: "**So first thing’s first - [install Docker](https://docs.docker.com/get-docker/).**"
-                      delay: 5500
-                    - text: Write me back when you're done. K?
-                      delay: 3000
-                - actionId: finish_step
+        if:
+          conditions:
+          - conditionId: user_has_feature_flag
+            params:
+              featureFlag: 'codespaces'
+          then:
+            do:
+            - actionId: bot_message
+              params:
+                person: head-of-rd
+                messages:
+                - text: At Anythink, our engineers work with a development environment that's hosted in the cloud called [Github Codespace](https://docs.github.com/en/codespaces/overview). No need to install anything on your own computer!
+                  delay: 2000
+                - text: Here's the link to [create your own codespace environment](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=${user.repoId}).
+                  delay: 1000
+                - text: It takes about a minute to boot. Once it's up and ready you can start working directly in the browser or use VS Code to connect to the codespace in the cloud.
+                  delay: 2000
+                - text: Go ahead and boot up your codespace, I'll wait.
+                  delay: 1000
+            - actionId: finish_step
+          else:
+            do:
+            - actionId: bot_message
+              params:
+                person: head-of-rd
+                messages:
+                - text: Before we dive into the code, we need Docker. It’s going to make
+                    it easier for us to run things locally, which we’ll have to do a lot
+                    during your work here.
+                  delay: 2000
+                - text: "**So first thing’s first - [install Docker](https://docs.docker.com/get-docker/).**"
+                  delay: 5500
+                - text: Write me back when you're done. K?
+                  delay: 3000
+            - actionId: finish_step
       else:
         do:
         - actionId: bot_message

--- a/steps/setup_frontend_docker_generic.yml
+++ b/steps/setup_frontend_docker_generic.yml
@@ -3,20 +3,41 @@ hints:
 - run `docker-compose up` from the root directory
 - make sure the network requests in the client are complete ok using the network tab.
 startFlow:
-  do:
-  - actionId: bot_message
-    params:
-      person: head-of-rd
-      messages:
-      - text: Now, it’s time to **check the frontend** and make sure it’s **connected
-          to the backend**.
-        delay: 2500
-      - text: If everything is working properly, you’ll be able to **create a new
-          user** on http://localhost:3001/register
-        delay: 3800
-      - text: Create one (choose a cool nickname and everything) and you’ll be able
-          to move to the next task.
-        delay: 2000
+  if:
+    conditions:
+    - conditionId: user_has_feature_flag
+      params:
+        featureFlag: 'codespaces'
+    then:
+      do:
+      - actionId: bot_message
+        params:
+          person: head-of-rd
+          messages:
+          - text: Now, it’s time to **check the frontend** and make sure it’s **connected
+              to the backend**.
+            delay: 2500
+          - text: If everything is working properly, you’ll be able to **create a new
+              user** on https://${user.codespace.name}-3001.githubpreview.dev/register
+            delay: 3800
+          - text: Create one (choose a cool nickname and everything) and you’ll be able
+              to move to the next task.
+            delay: 2000
+    else:
+      do:
+      - actionId: bot_message
+        params:
+          person: head-of-rd
+          messages:
+          - text: Now, it’s time to **check the frontend** and make sure it’s **connected
+              to the backend**.
+            delay: 2500
+          - text: If everything is working properly, you’ll be able to **create a new
+              user** on http://localhost:3001/register
+            delay: 3800
+          - text: Create one (choose a cool nickname and everything) and you’ll be able
+              to move to the next task.
+            delay: 2000
 trigger:
   type: local_page_load
   flowNode:


### PR DESCRIPTION
Clickup Card: [CU-2zak8ej](https://app.clickup.com/t/2zak8ej)

This PR:
1. Adds a split in the first dib `setup_docker_generic` where users in the codespaces experiment group that have the Feature Flag get a different string of messages with a prompt to go start their codespaces instead of downloading Docker.
2. Split dib `seutp_docker_continue_generic` into 2 dibs that are backwards compatible: `seutp_docker_continue_generic` and `seutp_docker_continue_codespace_generic`. Codespace users will automatically skip to the new dib, non codespace users will continue as normal and will skip when they get to the codespace dib.

The new trigger for `github_codespace_started` was added here: https://github.com/trywilco/wilco-engine/pull/1289

---

Testing:
- [x] As new user, no codespaces
- [x] As new user, with codesapces
- [x] As existing user, no codesapces