### PR TITLE
feat: update generic steps flags when doing the quest

### DIFF
--- a/steps/setup_docker_approve_notifications.yml
+++ b/steps/setup_docker_approve_notifications.yml
@@ -28,6 +28,11 @@ startFlow:
 trigger:
   type: chat_form_submitted
   flowNode:
+    do:
+      - actionId: update_user_props
+        params:
+          field: "onboarding.finishedBrowserNotificationsStep"
+          value: "true"
     if:
       conditions:
         - conditionId: text_contains_strings

--- a/steps/setup_docker_framework_selection.yml
+++ b/steps/setup_docker_framework_selection.yml
@@ -48,6 +48,10 @@ trigger:
         params:
           field: "frameworks.backend"
           value: "${{formSubmission}}"
+      - actionId: update_user_props
+        params:
+          field: "onboarding.finishedIntroToAnythinkStep"
+          value: "true"
       - actionId: bot_message
         params:
           person: head-of-rd


### PR DESCRIPTION
As part of running a migration for existing users to include the generic steps flag for finishing specific steps, this will ensure that users still have the docker local setup quest and will also update those flags.